### PR TITLE
Create separate api dir and export URLs endpoints

### DIFF
--- a/todo-list-application/client/src/App.jsx
+++ b/todo-list-application/client/src/App.jsx
@@ -4,6 +4,8 @@ import Input from "./components/Input.jsx"
 import ListItems from "./components/ListItems.jsx";
 import Auth from "./components/Auth.jsx";
 import axios from "axios";
+import { TODOS_URL, VERIFY_URL, SIGNOUT_URL } from "./api/endpoints";
+
 
 
 
@@ -15,8 +17,7 @@ function App() {
 
     async function manageAuth() {
             try{
-                const VITE_API_URL_VERIFY = import.meta.env.VITE_API_URL_VERIFY
-                const response = await axios.get(VITE_API_URL_VERIFY, {
+                const response = await axios.get(VERIFY_URL, {
                     withCredentials: true
                 })
                 response.data && setIsAuthenticated(true)
@@ -34,8 +35,7 @@ function App() {
 
     async function fetchData(){
         try{
-            const API_URL_GET = import.meta.env.VITE_API_URL_GET
-            const response = await axios.get(`${API_URL_GET}`, {
+            const response = await axios.get(`${TODOS_URL}`, {
                 withCredentials: true
             })
             const data = response.data
@@ -60,8 +60,7 @@ function App() {
 
     async function deleteItem(id) {
         try{
-            const API_URL_DELETE = import.meta.env.VITE_API_URL_DELETE;
-            await axios.delete(`${API_URL_DELETE}${id}`, {
+            await axios.delete(`${TODOS_URL}${id}`, {
                 withCredentials: true
             });
             setItems(items.filter(item => {
@@ -76,8 +75,7 @@ function App() {
 
     async function signOut() {
         try{
-            const VITE_API_URL_SIGNOUT = import.meta.env.VITE_API_URL_SIGNOUT
-            const response = await axios.post(VITE_API_URL_SIGNOUT, {
+            const response = await axios.post(SIGNOUT_URL, {
             }, {
                 withCredentials: true
             })

--- a/todo-list-application/client/src/api/endpoints.js
+++ b/todo-list-application/client/src/api/endpoints.js
@@ -1,0 +1,6 @@
+const BASE_URL = import.meta.env.VITE_API_URL;
+
+export const TODOS_URL = `${BASE_URL}${import.meta.env.VITE_API_PATH_TODOS}`;
+export const SUBMIT_URL = `${BASE_URL}${import.meta.env.VITE_API_PATH_SUBMIT}`;
+export const VERIFY_URL = `${BASE_URL}${import.meta.env.VITE_API_PATH_VERIFY}`;
+export const SIGNOUT_URL = `${BASE_URL}${import.meta.env.VITE_API_PATH_SIGNOUT}`;

--- a/todo-list-application/client/src/components/Edit.jsx
+++ b/todo-list-application/client/src/components/Edit.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import axios from "axios";
+import {TODOS_URL} from "../api/endpoints.js";
 
 
 function Edit({ item, onUpdate }) {
@@ -31,8 +32,7 @@ function Edit({ item, onUpdate }) {
 
     async function updateItem(){
         try{
-            const API_URL_PUT=import.meta.env.VITE_API_URL_PUT
-            const response = await axios.put(`${API_URL_PUT}${item.id}`,{description: editItem} ,{
+            const response = await axios.put(`${TODOS_URL}${item.id}`,{description: editItem} ,{
                 withCredentials: true
             });
             onUpdate(item.id,editItem)

--- a/todo-list-application/client/src/components/Input.jsx
+++ b/todo-list-application/client/src/components/Input.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import axios from "axios";
+import {SUBMIT_URL} from "../api/endpoints.js";
 
 
 
@@ -14,8 +15,7 @@ function Input(props) {
         e.preventDefault()
         if (inputText) {
             try{
-                const API_URL_POST = import.meta.env.VITE_API_URL_POST
-                await axios.post(API_URL_POST, {
+                await axios.post(SUBMIT_URL, {
                     description: inputText,
                 }, {
                     withCredentials: true


### PR DESCRIPTION
##  Refactor: Organize API Endpoints & Clean Up .env

### Summary
This PR improves the structure and maintainability of API endpoint management in the project by:

- Creating a new `api/` directory inside `src/`
- Adding a dedicated `endpoints.js` file to define and export full API URLs
- Updating `.env` to remove duplicate values and group base URLs and paths
- Refactoring `App.jsx` to use named imports for all API endpoint constants

---

### Changes Made

- `src/api/endpoints.js` created with named exports for:
  - `TODOS_URL`
  - `SUBMIT_URL`
  - `VERIFY_URL`
  - `SIGNOUT_URL`
- `.env` simplified to:
  ```env
  VITE_API_URL=http://localhost:3000
  VITE_API_PATH_TODOS=/todos/
  VITE_API_PATH_SUBMIT=/submit
  VITE_API_PATH_VERIFY=/verify
  VITE_API_PATH_SIGNOUT=/signout
  ```
- All Axios calls in App.jsx now use imported constants
- Code is cleaner, DRY, and easier to adapt for deployment or scaling
