### PR TITLE
Blog web application/truncated posts view

### DIFF
--- a/blog-web-application/index.js
+++ b/blog-web-application/index.js
@@ -48,6 +48,10 @@ app.get("/posts", (req, res) => {
     });
 });
 
+app.get("/posts/:postID", (req, res) => {
+    res.render("view-post.ejs")
+})
+
 app.get("/edit/:postID", (req, res) => {
     const postID = Number(req.params.postID);
     const foundPost = posts.find(p => p.id === postID);

--- a/blog-web-application/index.js
+++ b/blog-web-application/index.js
@@ -50,9 +50,24 @@ app.get("/posts", (req, res) => {
     });
 });
 
+
+// Getting a single post by postID
 app.get("/posts/:postID", (req, res) => {
-    res.render("view-post.ejs")
+    const postID = Number(req.params.postID);
+    if (isNaN(postID) || postID <= 0) {
+        return res.status(404).render("404.ejs")
+    }
+    const foundPost = posts.find(p => p.id === postID);
+    if (!foundPost) {
+        return res.status(404).render("404.ejs")
+    }
+    res.render("view-post.ejs", {
+        foundPost,
+    })
 })
+
+
+// Getting a specific post for editing
 
 app.get("/edit/:postID", (req, res) => {
     const postID = Number(req.params.postID);

--- a/blog-web-application/index.js
+++ b/blog-web-application/index.js
@@ -43,8 +43,10 @@ app.get("/posts", (req, res) => {
     if (posts.length === 0) {
         return res.redirect("/?noPosts=true");
     }
+    const reversedPosts = [...posts].reverse()
+
     res.render("posts.ejs", {
-        posts,
+        posts: reversedPosts,
     });
 });
 

--- a/blog-web-application/public/styles/main.css
+++ b/blog-web-application/public/styles/main.css
@@ -173,12 +173,9 @@ form button {
 }
 .posts-title {
     font-size: 1.7rem;
-    padding: 5px;
 }
 .post-text {
     white-space: pre-line;
-    padding: 5px;
-    margin-top: 0;
 }
 .post-text.preview {
     white-space: normal;

--- a/blog-web-application/public/styles/main.css
+++ b/blog-web-application/public/styles/main.css
@@ -178,6 +178,10 @@ form button {
 .post-text {
     white-space: pre-line;
     padding: 5px;
+    margin-top: 0;
+}
+.post-text.preview {
+    white-space: normal;
 }
 .author, .date {
     font-size: 0.8rem;

--- a/blog-web-application/public/styles/main.css
+++ b/blog-web-application/public/styles/main.css
@@ -181,7 +181,7 @@ form button {
     white-space: normal;
 }
 .author, .date {
-    font-size: 0.8rem;
+    font-size: 0.9rem;
 }
 .date {
     margin-top: 5px;
@@ -198,6 +198,22 @@ form button {
 .separator {
     border-top: 1px solid #c0c0c0;
     margin: 30px auto;
+}
+
+/*view-post styling*/
+.single-post-container {
+    color: black;
+    padding-top: 5rem;
+    flex-grow: 1;
+    width: 80%;
+}
+.single-post-content {
+    background-color: whitesmoke;
+    padding: 20px;
+    border-radius: 5px;
+}
+.post-meta {
+    font-size: 0.9rem;
 }
 .edit-btn {
     background-color:#ffc107 ;

--- a/blog-web-application/public/styles/script.js
+++ b/blog-web-application/public/styles/script.js
@@ -61,7 +61,7 @@ if (editForm) {
             }
 
             const result = await response.json();
-            window.location.href = "/posts"
+            window.location.href = `/posts/${postID}`
 
         } catch(err) {
             console.error(err.message);
@@ -82,7 +82,7 @@ deleteButton.forEach(button => {
             if (!confirmDelete) return
 
             try {
-                const response = await fetch(`posts/${postID}`, {
+                const response = await fetch(`/posts/${postID}`, {
                     method: "delete",
                     headers: {
                         "Content-Type": "application/json"
@@ -99,7 +99,7 @@ deleteButton.forEach(button => {
                 if (result.noPosts) {
                     window.location.href = "/?noPosts=true"
                 } else {
-                    window.location.reload()
+                    window.location.href= "/posts"
                 }
 
             } catch(err) {

--- a/blog-web-application/views/posts.ejs
+++ b/blog-web-application/views/posts.ejs
@@ -22,7 +22,7 @@
 <div class="posts-container">
     <div class="posts-content">
         <h1 class="posts-page-title">Your Blogs</h1>
-        <% posts.reverse().forEach((post) => { %>
+        <% posts.forEach((post) => { %>
             <h2 class="posts-title"><%= post.title %></h2>
             <% if (post.text.length > 100) { %>
                 <p class="post-text preview">

--- a/blog-web-application/views/posts.ejs
+++ b/blog-web-application/views/posts.ejs
@@ -33,8 +33,6 @@
             <% } %>
             <p class="author"><%= `By : ${post.author}` %></p>
             <p class="date"><%=post.date%></p>
-            <a class="edit-btn" href="/edit/<%= post.id %>">Edit</a>
-            <button class="delete-btn" data-id="<%= post.id %>">Delete</button>
             <div class="separator"></div>
         <% }) %>
     </div>

--- a/blog-web-application/views/view-post.ejs
+++ b/blog-web-application/views/view-post.ejs
@@ -13,33 +13,11 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Alice&family=Raleway:ital,wght@0,100..900;1,100..900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/styles/main.css">
+    <title>JournaLog - Home</title>
     <script src="/styles/script.js" defer></script>
-    <title>JournaLog - Posts</title>
+    <title>view-post</title>
 </head>
 <body>
-<main>
-<%- include("partials/header.ejs") %>
-<div class="posts-container">
-    <div class="posts-content">
-        <h1 class="posts-page-title">Your Blogs</h1>
-        <% posts.reverse().forEach((post) => { %>
-            <h2 class="posts-title"><%= post.title %></h2>
-            <% if (post.text.length > 100) { %>
-                <p class="post-text preview">
-                    <%= post.text.length > 100 ? post.text.slice(0,100).trim() + "...": post.text  %><small><a href="/posts/<%= post.id %>">Read more</a></small>
-                </p>
-            <% } else { %>
-                <p class="post-text preview"><%= post.text %></p>
-            <% } %>
-            <p class="author"><%= `By : ${post.author}` %></p>
-            <p class="date"><%=post.date%></p>
-            <a class="edit-btn" href="/edit/<%= post.id %>">Edit</a>
-            <button class="delete-btn" data-id="<%= post.id %>">Delete</button>
-            <div class="separator"></div>
-        <% }) %>
-    </div>
-</div>
-<%- include("partials/footer.ejs") %>
-</main>
+<h1>Hello World</h1>
 </body>
 </html>

--- a/blog-web-application/views/view-post.ejs
+++ b/blog-web-application/views/view-post.ejs
@@ -13,11 +13,22 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Alice&family=Raleway:ital,wght@0,100..900;1,100..900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/styles/main.css">
-    <title>JournaLog - Home</title>
+    <title>View post</title>
     <script src="/styles/script.js" defer></script>
-    <title>view-post</title>
 </head>
 <body>
-<h1>Hello World</h1>
+<main>
+    <%- include("partials/header.ejs") %>
+    <div class="single-post-container">
+        <div class="single-post-content">
+            <h1 class="post-title"><%= foundPost.title %></h1>
+            <p class="post-text"><%= foundPost.text %></p>
+            <p class="post-meta">By: <%= foundPost.author %> on <%= foundPost.date %></p>
+            <a class="edit-btn" href="/edit/<%= foundPost.id %>">Edit</a>
+            <button class="delete-btn" data-id="<%= foundPost.id %>">Delete</button>
+        </div>
+    </div>
+    <%- include("partials/footer.ejs") %>
+</main>
 </body>
 </html>


### PR DESCRIPTION
# Truncate Long Posts and Add Individual Post View

## Summary

This PR introduces two key features to improve post readability and navigation within the application:

1. **Post Preview Truncation:**  
   Posts on the main `/posts` page are now truncated to 100 characters, followed by a `Read more` link if applicable.
   
2. **Individual Post View (`/posts/:id`):**  
   Clicking `Read more` navigates the user to a dedicated `view-post.ejs` page for full post content, along with edit and delete options.

---

## Changes

- Truncate post content to 100 characters on the posts list.
- Append `Read more` anchor link to truncated posts.
- Add new EJS view: `view-post.ejs` to display full post content.
- Implement `GET /posts/:postID` backend route to serve full post view.
- Style `.post-text.preview` separately to ensure layout consistency.
- Fix reverse ordering issue using `[...posts].reverse()` to avoid mutating original array.
- Move Edit/Delete functionality into the post view page.
- Adjust redirect after edit to return to the updated post's detail page.

---

## Fixes

- Fixed non-deterministic order bug in `posts.ejs` caused by in-place `reverse()` mutation.
- Corrected incorrect redirect (`/view-post`) after PUT — now points to `/posts/:id`.

